### PR TITLE
Make TCC compile on RISC-V 64

### DIFF
--- a/riscv64-asm.c
+++ b/riscv64-asm.c
@@ -126,8 +126,8 @@ typedef struct Operand {
 } Operand;
 
 /* Fixed operands for pseudoinstructions */
-const Operand zero_imm = { OP_IM12S, 0};
-const Operand zero = { OP_REG, 0};
+const Operand zero_imm = {OP_IM12S, {0}};
+const Operand zero = {OP_REG, {0}};
 
 /* Parse a text containing operand and store the result in OP */
 static void parse_operand(TCCState *s1, Operand *op)
@@ -372,6 +372,7 @@ static void asm_shift_opcode(TCCState *s1, int token)
 static void asm_jump_opcode(TCCState* s1, int token)
 {
     Operand ops[3];
+    int offset;
     parse_operand(s1, &ops[0]);
     if (tok == ',')
         next();
@@ -403,7 +404,7 @@ static void asm_jump_opcode(TCCState* s1, int token)
          if(ops[1].type != OP_IM20S && ops[1].type != OP_IM12S)
              tcc_error("jal jump too large");
          /* Weird encoding. It doesn't let us use `asm_emit_u` easily */
-         int offset = 0;
+         offset = 0;
          offset  = ((ops[1].e.v & 0x100000)>>20) <<19 |
                    ((ops[1].e.v & 0x0FF000)>>12)      |
                    ((ops[1].e.v & 0x000800)>>11) <<8  |

--- a/riscv64-link.c
+++ b/riscv64-link.c
@@ -164,7 +164,9 @@ ST_FUNC void relocate_plt(TCCState *s1)
     if (s1->plt->reloc) {
         ElfW_Rel *rel;
         p = s1->got->data;
-        for_each_elem(s1->plt->reloc, 0, rel, ElfW_Rel) {
+        for (rel = (ElfW_Rel *) s1->plt->reloc->data; \
+             rel < (ElfW_Rel *) (s1->plt->reloc->data + s1->plt->reloc->data_offset); \
+             rel++) {
             write64le(p + rel->r_offset, s1->plt->sh_addr);
 	}
     }

--- a/tccelf.c
+++ b/tccelf.c
@@ -589,7 +589,7 @@ ST_FUNC void put_elf_reloc(Section *symtab, Section *s, unsigned long offset,
 ST_FUNC void squeeze_multi_relocs(Section *s, size_t oldrelocoffset)
 {
     Section *sr = s->reloc;
-    ElfW_Rel *r, *dest;
+    ElfW_Rel *r, *dest, tmp;
     ssize_t a;
     ElfW(Addr) addr;
 
@@ -608,7 +608,7 @@ ST_FUNC void squeeze_multi_relocs(Section *s, size_t oldrelocoffset)
 	for (; i >= (ssize_t)oldrelocoffset &&
                ei->r_offset > addr; i -= sizeof(*r)) {
             ei = (ElfW_Rel*)(sr->data + i);
-	    ElfW_Rel tmp = *(ElfW_Rel*)(sr->data + a);
+	    tmp = *(ElfW_Rel*)(sr->data + a);
 	    *(ElfW_Rel*)(sr->data + a) = *(ElfW_Rel*)(sr->data + i);
 	    *(ElfW_Rel*)(sr->data + i) = tmp;
 	}

--- a/tccpp.c
+++ b/tccpp.c
@@ -2180,6 +2180,10 @@ static void parse_number(const char *p)
     unsigned int bn[BN_SIZE];
     double d;
 
+    /* initialize values */
+    d = 0;
+    bn_zero(bn);
+
     /* number */
     q = token_buf;
     ch = *p++;

--- a/tccrun.c
+++ b/tccrun.c
@@ -702,8 +702,10 @@ static int rt_get_caller_pc(addr_t *paddr, ucontext_t *uc, int level)
 static int rt_get_caller_pc(addr_t *paddr, ucontext_t *uc, int level)
 {
     // TODO make sure api matches
-    if (level == 0) {
-        *paddr = uc->uc_mcontext.pc;
+    if (level < 0) {
+      return -1;
+    } else if (level == 0) {
+        *paddr = uc->uc_mcontext.__gregs[REG_PC];
     } else {
         addr_t *fp = (addr_t*)uc->uc_mcontext.__gregs[REG_S0]; // REG_S0 == 8
         while (--level && fp >= (addr_t*)0x1000)


### PR DESCRIPTION
This is a quick-and-dirty set of changes to make tcc compile for RISCV64 using a native, emulated gcc. It's not clear that any of these changes are "correct," just that they compile. Notably, the change to rt_get_caller_pc requires breaking into opaque structs; the actual internals of these structs aren't available anywhere I could find. Also, it would be nice to use for_each_elem in riscv64-link.c, and to use the existing definitions of vpushsym and vsetc in riscv64-gen.c because DRY; this would require relocating that code to an appropriate header.

* riscv64-asm.c: Properly initialize union inside Operand structs to 0. (asm_shift_opcode): Separate variable declaration and initialization for C90 compliance.
* riscv64-gen.c (vsetc, vpushsym): Add vsetc. Add vpushsym.
* riscv64-link.c (relocate_plt): Replace for_each_elem macro with its definition.
* tccelf.c (put_elf_reloc): Separate variable declaration and initialization for C90 compliance.
* tccpp.c (parse_number): Initialize uninitialized values.
* tccrun.c (rt_get_caller_pc): Properly access PC in uc_mcontext, return -1 on level < 0.